### PR TITLE
Replace hard-coded AnonymousUsage value with a configurable template parameter

### DIFF
--- a/cloudformationTemplates/asyncCustomerChatUX/cloudformation.yaml
+++ b/cloudformationTemplates/asyncCustomerChatUX/cloudformation.yaml
@@ -11,9 +11,6 @@ Mappings:
       S3Bucket: "amazon-connect-advanced-customer-chat-cfn"
       S3Key: "deployment/"
       SolutionID: "AC0001"
-  Send:
-    AnonymousUsage:
-      Data: "Yes"
 
 Parameters:
   WebsiteS3BucketName:

--- a/cloudformationTemplates/asyncCustomerChatUX/cloudformation.yaml
+++ b/cloudformationTemplates/asyncCustomerChatUX/cloudformation.yaml
@@ -4,7 +4,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 
 Description: >
   "Customer chat solution for Amazon Connect"
-  
+
 Mappings:
   FunctionMap:
     Configuration:
@@ -53,6 +53,16 @@ Parameters:
       - PriceClass_All
     ConstraintDescription: "Allowed Price Classes PriceClass_100 PriceClass_200 and PriceClass_All"
     Description: Specify the CloudFront price class. See https://aws.amazon.com/cloudfront/pricing/ for a description of each price class.
+  allowAnonymousUsageMetrics:
+    Type: String
+    Default: "Yes"
+    AllowedValues:
+      - "Yes"
+      - "No"
+    Description: Send usage metrics about this CloudFormation stack to AWS
+
+Conditions:
+  AnonymousUsageMetrics: !Equals [ !Ref allowAnonymousUsageMetrics, "Yes"]
 
 Resources:
 
@@ -71,7 +81,7 @@ Resources:
               - !FindInMap [FunctionMap, Configuration, S3Bucket]
         S3Key: !Join ["", [!FindInMap [FunctionMap, Configuration, S3Key], 'ChatSDK.zip']]
       Description: The AWS SDK including Amazon Connect Chat APIs.
-  
+
   InitiateChatLambda:
     Type: "AWS::Lambda::Function"
     Properties:
@@ -137,7 +147,7 @@ Resources:
                 Resource:
                   - !GetAtt chatContactDataTable.Arn
                   - !Sub "${chatContactDataTable.Arn}/index/*"
-  
+
   UpdateDdbWithS3LocationLambda:
     Type: "AWS::Lambda::Function"
     Properties:
@@ -254,37 +264,37 @@ Resources:
   #### DynamoDb ####
   chatContactDataTable:
     Type: AWS::DynamoDB::Table
-    Properties: 
-      AttributeDefinitions: 
-        - 
+    Properties:
+      AttributeDefinitions:
+        -
           AttributeName: "contactId"
           AttributeType: "S"
-        - 
+        -
           AttributeName: "nextContactId"
           AttributeType: "S"
-        - 
+        -
           AttributeName: "userDisplayHash"
           AttributeType: "S"
-      KeySchema: 
-        - 
+      KeySchema:
+        -
           AttributeName: "contactId"
           KeyType: "HASH"
-      ProvisionedThroughput: 
+      ProvisionedThroughput:
         ReadCapacityUnits: 5
         WriteCapacityUnits: 5
-      GlobalSecondaryIndexes: 
-        - 
+      GlobalSecondaryIndexes:
+        -
           IndexName: "userDisplayHash-nextContactId-index"
-          KeySchema: 
-            - 
+          KeySchema:
+            -
               AttributeName: "userDisplayHash"
               KeyType: "HASH"
-            - 
+            -
               AttributeName: "nextContactId"
               KeyType: "RANGE"
           Projection:
             ProjectionType: "ALL"
-          ProvisionedThroughput: 
+          ProvisionedThroughput:
             ReadCapacityUnits: 5
             WriteCapacityUnits: 5
       TimeToLiveSpecification:
@@ -412,18 +422,19 @@ Resources:
       destS3Bucket: !Ref WebsiteS3BucketName
       destS3KeyPrefix: contents/
       UUID: !GetAtt SolutionUuid.UUID
-      data: !FindInMap [Send, AnonymousUsage, Data]
+      data: !Ref allowAnonymousUsageMetrics
       solutionId: !FindInMap [FunctionMap, Configuration, SolutionID]
 
   SolutionAnonymousMetric:
     Type: "Custom::LoadLambda"
+    Condition: AnonymousUsageMetrics
     Properties:
       ServiceToken: !GetAtt CustomResourceHelper.Arn
       Region: !Ref AWS::Region
       solutionId: !FindInMap ["FunctionMap", "Configuration", "SolutionID"]
       UUID: !GetAtt SolutionUuid.UUID
       version: "1"
-      anonymousData: !FindInMap ["Send", "AnonymousUsage", "Data"]
+      anonymousData: !Ref allowAnonymousUsageMetrics
       customAction: "sendMetric"
 
   SolutionUuid:

--- a/cloudformationTemplates/startChatContactAPI/cloudformation.yaml
+++ b/cloudformationTemplates/startChatContactAPI/cloudformation.yaml
@@ -10,9 +10,6 @@ Mappings:
       S3Bucket: "start-chat-contact-api-cfn"
       S3Key: "deployment/"
       SolutionID: "AC0002"
-  Send:
-    AnonymousUsage:
-      Data: "Yes"
 
 Parameters:
   contactFlowId:

--- a/cloudformationTemplates/startChatContactAPI/cloudformation.yaml
+++ b/cloudformationTemplates/startChatContactAPI/cloudformation.yaml
@@ -25,6 +25,16 @@ Parameters:
     Default: 12345678-1234-1234-1234-123456789012
     Description: The instance id of the Amazon Connect instance that the customer will interact with while chatting
     AllowedPattern: '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}'
+  allowAnonymousUsageMetrics:
+    Type: String
+    Default: "Yes"
+    AllowedValues:
+      - "Yes"
+      - "No"
+    Description: Send usage metrics about this CloudFormation stack to AWS
+
+Conditions:
+  AnonymousUsageMetrics: !Equals [ !Ref allowAnonymousUsageMetrics, "Yes"]
 
 Outputs:
   StartChatLambda:
@@ -252,6 +262,7 @@ Resources:
 
   SolutionAnonymousMetric:
     Type: "Custom::LoadLambda"
+    Condition: AnonymousUsageMetrics
     Properties:
       ServiceToken:
         Fn::GetAtt:
@@ -262,7 +273,7 @@ Resources:
       solutionId: !FindInMap ["FunctionMap", "Configuration", "SolutionID"]
       UUID: !GetAtt SolutionUuid.UUID
       version: "1"
-      anonymousData: !FindInMap ["Send", "AnonymousUsage", "Data"]
+      anonymousData: !Ref allowAnonymousUsageMetrics
       customAction: "sendMetric"
 
   SolutionUuid:


### PR DESCRIPTION
*Description of changes:*
This pull-request replaces the hard-coded `AnonymousUsage` mapping with a `allowAnonymousUsageMetrics` template parameter. The parameter allows two values: `Yes` and `No`. The default parameter value is `Yes`.

Setting the `allowAnonymousUsageMetrics` to `No` prevents the conditional `SolutionAnonymousMetric` resource from being created, which disables submitting usage metrics to `metrics.awssolutionsbuilder.com`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
