### PR TITLE
Fix - S3BucketConfigurationLambdaExecutionRole

### DIFF
--- a/cloudformationTemplates/asyncCustomerChatUX/cloudformation.yaml
+++ b/cloudformationTemplates/asyncCustomerChatUX/cloudformation.yaml
@@ -239,6 +239,17 @@ Resources:
               - "sts:AssumeRole"
       Path: "/"
       Policies:
+        - PolicyName: S3BucketConfigurationLambdaLogPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - logs:CreateLogStream
+                  - logs:CreateLogGroup
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
         - PolicyName: get-previous-chat-policy
           PolicyDocument:
             Version: "2012-10-17"


### PR DESCRIPTION
*Issue #27*

*Description of changes:*
Fixed S3BucketConfigurationLambdaExecutionRole policy to allow Lambda to write to CloudWatch logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
