### PR TITLE
create issue/ticket template forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: "\U0001F41B Bug, Pending Research"
+assignees: ''
+
+---
+
+**Which Example?**
+- [ ] startChatContactAPI (cfnTemplate)
+- [ ] urlPreviewForAsyncChat (cfnTemplate)
+- [ ] customChatWidget
+- [ ] connectReactNativeChat
+- [ ] amazon-connect-interactive-messages-example (samTemplate)
+- [ ] amazon-connect-chat-interface ([repository](https://github.com/amazon-connect/amazon-connect-chat-interface))
+- [ ] amazon-connect ChatJS ([repository](https://github.com/amazon-connect/amazon-connect-chatjs))
+- [ ] Other
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. 
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation-question.md
+++ b/.github/ISSUE_TEMPLATE/documentation-question.md
@@ -1,0 +1,27 @@
+---
+name: Documentation Question
+about: Ask about documentation or missing details.
+title: "[Documentation]"
+labels: "\U0001F4DD Documentation, Pending Research"
+assignees: ''
+
+---
+
+**Which Example?**
+- [ ] startChatContactAPI (cfnTemplate)
+- [ ] urlPreviewForAsyncChat (cfnTemplate)
+- [ ] customChatWidget
+- [ ] connectReactNativeChat
+- [ ] amazon-connect-interactive-messages-example (samTemplate)
+- [ ] amazon-connect-chat-interface ([repository](https://github.com/amazon-connect/amazon-connect-chat-interface))
+- [ ] amazon-connect ChatJS ([repository](https://github.com/amazon-connect/amazon-connect-chatjs))
+- [ ] Other
+
+**Question:**
+Please describe your question here
+
+**Additional context**
+Add any other context about the problem here.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature]"
+labels: "\U0001F680 Feature, Pending Research"
+assignees: ''
+
+---
+
+- [ ] startChatContactAPI (cfnTemplate)
+- [ ] urlPreviewForAsyncChat (cfnTemplate)
+- [ ] customChatWidget
+- [ ] connectReactNativeChat
+- [ ] amazon-connect-interactive-messages-example (samTemplate)
+- [ ] amazon-connect-chat-interface ([repository](https://github.com/amazon-connect/amazon-connect-chat-interface))
+- [ ] amazon-connect ChatJS ([repository](https://github.com/amazon-connect/amazon-connect-chatjs))
+- [ ] Other
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Create GitHub issue templates. Customer not providing enough details to debug, so this will prompt them to include more details.


### Example

<img width="648" alt="Screenshot 2023-10-09 at 10 13 06 AM" src="https://github.com/amazon-connect/amazon-connect-chat-ui-examples/assets/60903378/438e195d-2ab8-4ce5-b50e-7e58b49bda2b">

