### PR TITLE
add ACL config to the bucket and update nodejs version

### DIFF
--- a/cloudformationTemplates/urlPreviewForAsyncChat/cloudformation.yaml
+++ b/cloudformationTemplates/urlPreviewForAsyncChat/cloudformation.yaml
@@ -124,7 +124,7 @@ Resources:
     Properties:
       CompatibleRuntimes:
         - "nodejs14.x"
-        - "nodejs12.x"
+        - "nodejs18.x"
       Content:
         S3Bucket: !Join
           - "."
@@ -146,7 +146,7 @@ Resources:
       Description: AWS Lambda Function to generate URL preview
       Handler: "AmazonConnectChatLinkPreviewLambdaEntryPoint.handler"
       Role: !GetAtt UrlPreviewLambdaExecutionRole.Arn
-      Runtime: "nodejs12.x"
+      Runtime: "nodejs18.x"
       MemorySize: 128
       Timeout: 300
       Layers:
@@ -433,6 +433,9 @@ Resources:
         BlockPublicPolicy: True
         IgnorePublicAcls: True
         RestrictPublicBuckets: True
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
       CorsConfiguration:
         CorsRules:
           - AllowedHeaders:


### PR DESCRIPTION
*Issue #, if available:*
Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting (Service: S3, Status Code: 400, Request ID: NJWP0HPSQCX6CG3Y, Extended Request ID: NA7YpjnoVGojEVrTpoOwn19iwOVp1vmjPj7uEvVRRej0UA181RAoSya7fYI3L7aK2fjKaL4/n+Y=)" (RequestToken: 14bb09ca-e3d0-8d92-d582-a00a457c83cb, HandlerErrorCode: GeneralServiceException).

*Description of changes:*
add ACL config to the bucket and update nodejs version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
