### PR TITLE
upgrade to Node 20 for React Native CI

### DIFF
--- a/.github/workflows/reactnative-node-ci.yml
+++ b/.github/workflows/reactnative-node-ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        node-version: [16.x] # 18.x, 19.x
+        node-version: [20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     defaults:
       run:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
upgrade to Node 20 for React Native CI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
