### PR TITLE
Adding S3 bucket encryption to cloudformation templates

### DIFF
--- a/cloudformationTemplates/asyncCustomerChatUX/cloudformation.yaml
+++ b/cloudformationTemplates/asyncCustomerChatUX/cloudformation.yaml
@@ -353,6 +353,10 @@ Resources:
             AllowedOrigins:
               - "*" #!Sub "https://${CloudFrontDistribution.DomainName}"
             MaxAge: 3000
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
 
   s3BucketPolicy:
     Type: AWS::S3::BucketPolicy

--- a/cloudformationTemplates/urlPreviewForAsyncChat/cloudformation.yaml
+++ b/cloudformationTemplates/urlPreviewForAsyncChat/cloudformation.yaml
@@ -446,6 +446,10 @@ Resources:
             AllowedOrigins:
               - "*" #!Sub "https://${CloudFrontDistribution.DomainName}"
             MaxAge: 3000
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
 
   s3BucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
*Description of changes:*

This PR adds bucket encryption to `asyncCustomerChatUX` (deprecated) and `urlPreviewForAsyncChat` `cloudformation.yaml` files.

See [AWS::S3::Bucket BucketEncryption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-bucketencryption.html) for more details on bucket encryption.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
