### PR TITLE
Fixing auto-launch compatibility with iOS WebView Example

### DIFF
--- a/mobileChatExamples/iOS-WKWebView-sample/WkWebView Demo/Base.lproj/Main.storyboard
+++ b/mobileChatExamples/iOS-WKWebView-sample/WkWebView Demo/Base.lproj/Main.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Connect Widget View Controller-->
+        <!--Start View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ConnectWidgetViewController" customModule="WkWebView_Demo" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="StartViewController" customModule="WkWebView_Demo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/mobileChatExamples/iOS-WKWebView-sample/WkWebView Demo/ConnectWidgetViewController.swift
+++ b/mobileChatExamples/iOS-WKWebView-sample/WkWebView Demo/ConnectWidgetViewController.swift
@@ -11,8 +11,8 @@ import UIKit
 import WebKit
 
 class ConnectWidgetViewController: UIViewController {
-    private let connectWidgetWebView = ConnectWidgetWebView()
-    
+    private let connectWidgetWebView: ConnectWidgetWebView = ConnectWidgetWebView()
+        
     override func viewDidLoad() {
         super.viewDidLoad()
         view.addSubview(connectWidgetWebView)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When using Connect Widget with `skipIconButtonAndAutoLaunch` enabled, there was an issue where a ghost chat would enter the queue when the app was launched, before navigating to the webview.  This was because the `ConnectWidgetWebViewController` was set as the initial view for the storyboard, so it was being initialized and auto-launched once the app initially launched.

The correct initial view should be the `StartView`.  Updating the initial storyboard view fixed the issue because the `ConnectWidgetWebViewController` was now being initialized as needed instead of initialized at app launch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
