### PR TITLE
Revert bundle identifier and team in project settings to fix the buil…

### DIFF
--- a/mobileChatExamples/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/project.pbxproj
+++ b/mobileChatExamples/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7N8D4W3RYX;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -367,7 +367,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.blitz.Chat.PushNotificationExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = mikeliao.webview.demo.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
@@ -385,7 +385,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7N8D4W3RYX;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -400,7 +400,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.blitz.Chat.PushNotificationExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = mikeliao.webview.demo.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -538,13 +538,13 @@
 				CODE_SIGN_ENTITLEMENTS = "WkWebView Demo/WkWebView Demo.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7N8D4W3RYX;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "WkWebView Demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.blitz.Chat;
+				PRODUCT_BUNDLE_IDENTIFIER = mikeliao.webview.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -561,13 +561,13 @@
 				CODE_SIGN_ENTITLEMENTS = "WkWebView Demo/WkWebView Demo.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7N8D4W3RYX;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "WkWebView Demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.blitz.Chat;
+				PRODUCT_BUNDLE_IDENTIFIER = mikeliao.webview.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -580,14 +580,14 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7N8D4W3RYX;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "WkWebView DemoUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.blitz.Chat;
+				PRODUCT_BUNDLE_IDENTIFIER = mikeliao.webview.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -600,14 +600,14 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7N8D4W3RYX;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "WkWebView DemoUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.blitz.Chat;
+				PRODUCT_BUNDLE_IDENTIFIER = mikeliao.webview.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
…d issue

*Description of changes:*

This change reverts unexpected team and bundle identifier updates in previous [PR](https://github.com/amazon-connect/amazon-connect-chat-ui-examples/pull/251/files#diff-d6e7f46c8d1d9f6b1fce4b6b3a0fe8ea752fdf40204ce95da6180e3e33639286) that added example code to integrate push notification. The changes were causing the build to fail unless user enabled push notification and updated those settings.
Tested and confirmed the app can be built and installed successfully without editing project settings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
