### PR TITLE
polyfill react native demo app to work with AWS SDK v3

### DIFF
--- a/mobileChatExamples/connectReactNativeChat/App.js
+++ b/mobileChatExamples/connectReactNativeChat/App.js
@@ -1,3 +1,4 @@
+import './src/polyfills';
 import React from 'react';
 import ChatUI from "./src/ChatUI";
 

--- a/mobileChatExamples/connectReactNativeChat/README.md
+++ b/mobileChatExamples/connectReactNativeChat/README.md
@@ -62,7 +62,7 @@ This step is already provided in the demo app, feel free to skip to the next sec
 
 ChatJS relies on browser's `window.navigator.onLine` for network monitoring, which isn't available in React Native (Hermes JS Engine). Instead, you'll need to configure ChatJS to use React Native's NetInfo API for network status checks.
 
-> 📌 Important: ensure you are using `amazon-connect-chatjs >= v1.5.0` (`>=1.5.0 <=3.0.2`)
+> 📌 Important: ensure you are using `amazon-connect-chatjs >= v1.5.0`
 
 ```diff
 // MyComponents.jsx
@@ -104,7 +104,19 @@ const MyComponent = () => {
 }
 ```
 
-6. Run locally
+6. Configure polyfills for missing Web APIs in React Native environment.
+
+For `amazon-connect-chatjs >= v3.0.3`, you need to configure polyfills to support certain Web APIs. These include:
+ * Crypto
+ * ReadableStream
+ * TextEncoding
+ * ArrayBuffer
+
+If you're using the demo app, you can skip this step. The necessary polyfill configuration is already included in the  `src/polyfills.js` file.
+
+However, if you're building a React Native application that relies on ChatJS, you'll need to set up these polyfills yourself.
+
+7. Run locally
 
 ```sh
 # run on http://localhost:PORT

--- a/mobileChatExamples/connectReactNativeChat/package-lock.json
+++ b/mobileChatExamples/connectReactNativeChat/package-lock.json
@@ -15,7 +15,7 @@
         "@react-native/assets-registry": "^0.79.1",
         "@react-navigation/native": "^6.1.6",
         "@react-navigation/stack": "^6.3.16",
-        "amazon-connect-chatjs": "^3.0.2",
+        "amazon-connect-chatjs": "^3.1.1",
         "axios": "^1.8.2",
         "babel-plugin-module-resolver": "^5.0.2",
         "buffer": "^6.0.3",
@@ -1135,13 +1135,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.7.tgz",
-      "integrity": "sha512-HMXK3WbBPpZQufbMG4B46A90PkuuhN9vBCb5T8+VAHqvAqvcLi+2cKoukcpmUYkszLhScU3l1iudhrks3DggRQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
+      "integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/plugin-syntax-class-static-block": "^7.14.5"
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6778,9 +6778,10 @@
       }
     },
     "node_modules/amazon-connect-chatjs": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/amazon-connect-chatjs/-/amazon-connect-chatjs-3.0.2.tgz",
-      "integrity": "sha512-xHma7QJ3L4cpH8l3qpntXBvlSKVjSWOsGNbmNxcTfQFPCkNxiAWNEkupD87Eki6DzAvM9lV5QLiM6+SdwaTX9w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/amazon-connect-chatjs/-/amazon-connect-chatjs-3.1.1.tgz",
+      "integrity": "sha512-pit9ZrQRrrpbplnohb46VA8HkmICqPs/Al8RISbdrFVcrhkxadThdKHkT/0aJfgNwDQEnDkcC3rn9ZAKewbFFg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "detect-browser": "5.3.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -20016,6 +20017,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz",
       "integrity": "sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==",
+      "license": "MIT",
       "dependencies": {
         "fast-base64-decode": "^1.0.0"
       },
@@ -20231,6 +20233,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz",
       "integrity": "sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -22930,6 +22933,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.1.0.tgz",
       "integrity": "sha512-A7Jxrg7+eV+eZR/CIdESDnRGFb6/bcKukGvJBB5snI6cw3is1c2qamkYstC1bY1p08TyMRlN9eTMkxmnKJBPBw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }

--- a/mobileChatExamples/connectReactNativeChat/package.json
+++ b/mobileChatExamples/connectReactNativeChat/package.json
@@ -25,7 +25,7 @@
     "@react-native/assets-registry": "^0.79.1",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/stack": "^6.3.16",
-    "amazon-connect-chatjs": ">=1.5.0 <=3.0.2",
+    "amazon-connect-chatjs": "^3.1.1",
     "axios": "^1.8.2",
     "babel-plugin-module-resolver": "^5.0.2",
     "buffer": "^6.0.3",

--- a/mobileChatExamples/connectReactNativeChat/src/polyfills.js
+++ b/mobileChatExamples/connectReactNativeChat/src/polyfills.js
@@ -1,0 +1,34 @@
+import 'react-native-get-random-values'; // polyfill for Crypto getRandomValues() method
+import { polyfill as polyfillEncoding } from 'react-native-polyfill-globals/src/encoding';
+import { ReadableStream } from "web-streams-polyfill";
+
+//polyfill for readable stream
+if (typeof global.ReadableStream !== 'function') {
+  global.ReadableStream = ReadableStream;
+}
+
+
+//polyfill for arrayBuffer
+if (!global.Response || !global.Response.prototype.arrayBuffer) {
+  if (global.Response) {
+    global.Response.prototype.arrayBuffer = function() {
+      return Promise.resolve(this._bodyInit);
+    };
+  }
+}
+
+// Also ensure Blob has arrayBuffer method
+if (global.Blob && !global.Blob.prototype.arrayBuffer) {
+  global.Blob.prototype.arrayBuffer = function() {
+    return new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        resolve(reader.result);
+      };
+      reader.readAsArrayBuffer(this);
+    });
+  };
+}
+
+//polyfill for text encoding
+polyfillEncoding();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Reason of the change:
The React Native demo app's dependency - `ChatJS`, has been updated to use AWS-SDK-JS v3. This new version relies on certain Web APIs that are not natively available in the React Native environment. To ensure compatibility, we need to implement polyfills for the following:
 * Crypto.getRandomValues()
 * ReadableStream
 * TextEncoding
 * ArrayBuffer

Key updates : 
* Created a new `src/polyfills.js` file to patches missing  supported web APIs.
* Integrated polyfills into the main - `App.js` file
* Updated `amazon-connect-chatjs` to the latest version (3.1.1)
* Modified the README to include instructions for configuring polyfills

Recording of manual testing:
* With the polyfill changes, the React Native demo app works well with `amazon-connect-chatjs`  latest version (3.1.1)
* [Recording Link](https://drive.corp.amazon.com/documents/fuxinhui@/Fix_ReactNativeDemoApp_AWS_SDK_V3/fix_ReactNativeDemoApp_AWS-SDK-v3.mov)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
