### PR TITLE
[iOSChatExample] feat: Add retry functionality for failed messages 

### DIFF
--- a/mobileChatExamples/iOSChatExample/AmazonConnectChatIOSDemo/Models/ChatManager.swift
+++ b/mobileChatExamples/iOSChatExample/AmazonConnectChatIOSDemo/Models/ChatManager.swift
@@ -278,6 +278,26 @@ class ChatManager: ObservableObject {
         }
     }
     
+    /// Resends a failed message using the SDK's resendFailedMessage API
+    func resendFailedMessage(messageId: String) {
+        self.chatSession.resendFailedMessage(messageId: messageId) { [weak self] result in
+            self?.handleMessageResendResult(result, messageId: messageId)
+        }
+    }
+    
+    // Handles the result of resending a failed message
+    private func handleMessageResendResult(_ result: Result<Void, Error>, messageId: String) {
+        DispatchQueue.main.async {
+            switch result {
+            case .success:
+                print("Message resent successfully for messageId: \(messageId)")
+            case .failure(let error):
+                print("Error resending message: \(error.localizedDescription)")
+                self.error = ErrorMessage(message: "Error resending message: \(error.localizedDescription)")
+            }
+        }
+    }
+    
     /// Disconnects the chat session
     func disconnectChat() {
         // Remove the participant token

--- a/mobileChatExamples/iOSChatExample/AmazonConnectChatIOSDemo/Views/AttachmentMessageView.swift
+++ b/mobileChatExamples/iOSChatExample/AmazonConnectChatIOSDemo/Views/AttachmentMessageView.swift
@@ -80,8 +80,8 @@ struct AttachmentMessageView: View {
             
             if message.messageDirection == .Outgoing, let metadata = message.metadata {
                 HStack(spacing: 2) {
-                    // Show status for recent outgoing message or failed messages
-                    if message.id == recentOutgoingMessageID || metadata.status == .Failed {
+                    // Show status for recent outgoing message, failed messages, or sending messages
+                    if message.id == recentOutgoingMessageID || metadata.status == .Failed || metadata.status == .Sending {
                         Text(CommonUtils.customMessageStatus(for: metadata.status)).font(.caption2).foregroundColor(.gray)
                         
                         // Show retry button for failed attachments

--- a/mobileChatExamples/iOSChatExample/AmazonConnectChatIOSDemo/Views/AttachmentMessageView.swift
+++ b/mobileChatExamples/iOSChatExample/AmazonConnectChatIOSDemo/Views/AttachmentMessageView.swift
@@ -78,9 +78,25 @@ struct AttachmentMessageView: View {
             .cornerRadius(8)
             .frame(maxWidth: UIScreen.main.bounds.size.width * 0.75, alignment: .leading)
             
-            if message.messageDirection == .Outgoing, let metadata = message.metadata, message.id == recentOutgoingMessageID {
+            if message.messageDirection == .Outgoing, let metadata = message.metadata {
                 HStack(spacing: 2) {
-                    Text(CommonUtils.customMessageStatus(for: metadata.status)).font(.caption2).foregroundColor(.gray)
+                    // Show status for recent outgoing message or failed messages
+                    if message.id == recentOutgoingMessageID || metadata.status == .Failed {
+                        Text(CommonUtils.customMessageStatus(for: metadata.status)).font(.caption2).foregroundColor(.gray)
+                        
+                        // Show retry button for failed attachments
+                        if metadata.status == .Failed {
+                            Button(action: {
+                                chatManager.resendFailedMessage(messageId: message.id)
+                            }) {
+                                Text("Retry")
+                                    .font(.caption2)
+                                    .foregroundColor(.blue)
+                                    .underline()
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                        }
+                    }
                 }.frame(maxWidth: UIScreen.main.bounds.size.width * 0.75, alignment: .trailing)
             }
             

--- a/mobileChatExamples/iOSChatExample/AmazonConnectChatIOSDemo/Views/ChatMessageView.swift
+++ b/mobileChatExamples/iOSChatExample/AmazonConnectChatIOSDemo/Views/ChatMessageView.swift
@@ -112,8 +112,8 @@ struct SenderChatBubble: View {
             
             if let metadata = message.metadata {
                 HStack(spacing: 2) {
-                    // Show status for recent outgoing message or failed messages
-                    if message.id == recentOutgoingMessageID || metadata.status == .Failed {
+                    // Show status for recent outgoing message, failed messages, or sending messages
+                    if message.id == recentOutgoingMessageID || metadata.status == .Failed || metadata.status == .Sending {
                         Text(CommonUtils.customMessageStatus(for: metadata.status)).font(.caption2).foregroundColor(.gray)
                         
                         // Show retry button for failed messages

--- a/mobileChatExamples/iOSChatExample/AmazonConnectChatIOSDemoTests/AmazonConnectChatIOSDemoTests.swift
+++ b/mobileChatExamples/iOSChatExample/AmazonConnectChatIOSDemoTests/AmazonConnectChatIOSDemoTests.swift
@@ -28,5 +28,17 @@ final class AmazonConnectChatIOSDemoTests: XCTestCase {
             // Put the code you want to measure the time of here.
         }
     }
+    
+    func testChatManagerHasResendFailedMessageMethod() throws {
+        // Test that ChatManager has the resendFailedMessage method
+        let chatManager = ChatManager()
+        
+        // This test verifies that the method exists and can be called
+        // In a real scenario, this would require a proper chat session setup
+        let testMessageId = "test-message-id"
+        
+        // The method should exist and be callable (though it may fail without proper setup)
+        XCTAssertNoThrow(chatManager.resendFailedMessage(messageId: testMessageId))
+    }
 
 }


### PR DESCRIPTION
- Add resendFailedMessage method to ChatManager that calls SDK's resendFailedMessage API
- Update SenderChatBubble to show retry button for failed text messages
- Update AttachmentMessageView to show retry button for failed attachments
- Display retry button for any failed message, not just recent ones
- Add proper async handling to prevent SwiftUI publishing warnings
- Add basic test to verify resendFailedMessage method exists
- Maintain consistent UI styling with blue underlined retry links

Fixes issue where users couldn't retry messages that failed to send.
![simulator_screenshot_59E05AD9-E93D-4CF1-BA7E-47FCC52F127D](https://github.com/user-attachments/assets/0ad71c0e-c7bc-47b4-8cfc-409059f80456)
![simulator_screenshot_F782726E-D7C2-44D4-A8BC-A7F018AC99E6](https://github.com/user-attachments/assets/97170bb3-cdb0-480d-883c-33e99eb46fd1)




Tested failed to send attachments as well

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
