### PR TITLE
Creating region restrictions for cloudformationTemplates

### DIFF
--- a/cloudformationTemplates/asyncCustomerChatUX/cloudformation.yaml
+++ b/cloudformationTemplates/asyncCustomerChatUX/cloudformation.yaml
@@ -11,6 +11,25 @@ Mappings:
       S3Bucket: "amazon-connect-advanced-customer-chat-cfn"
       S3Key: "deployment/"
       SolutionID: "AC0001"
+  AllowedRegions:
+    us-east-1:
+      Allowed: "true"
+    us-west-2:
+      Allowed: "true"
+    ap-southeast-2:
+      Allowed: "true"
+    ap-northeast-1:
+      Allowed: "true"
+    eu-central-1:
+      Allowed: "true"
+    eu-west-2:
+      Allowed: "true"
+    ap-southeast-1:
+      Allowed: "true"
+    ca-central-1:
+      Allowed: "true"
+    ap-northeast-2:
+      Allowed: "true"
 
 Parameters:
   WebsiteS3BucketName:
@@ -68,11 +87,13 @@ Parameters:
 
 Conditions:
   AnonymousUsageMetrics: !Equals [!Ref allowAnonymousUsageMetrics, "Yes"]
+  IsAllowedRegion: !Equals [!FindInMap [AllowedRegions, !Ref "AWS::Region", Allowed], "true"]
 
 Resources:
   #### Lambda #####
   ChatSDKLayer:
     Type: AWS::Lambda::LayerVersion
+    Condition: IsAllowedRegion
     Properties:
       CompatibleRuntimes:
         - "nodejs14.x"
@@ -90,6 +111,7 @@ Resources:
 
   InitiateChatLambda:
     Type: "AWS::Lambda::Function"
+    Condition: IsAllowedRegion
     Properties:
       Description: AWS Lambda Function to initiate the chat with the end user
       Handler: "startChatContact.handler"
@@ -122,6 +144,7 @@ Resources:
 
   InitiateChatLambdaExecutionRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -162,6 +185,7 @@ Resources:
 
   UpdateDdbWithS3LocationLambda:
     Type: "AWS::Lambda::Function"
+    Condition: IsAllowedRegion
     Properties:
       Description: AWS Lambda Function to update the DDB with the S3 location of the chat transcript
       Handler: "updateChatDdbWithS3Key.handler"
@@ -189,6 +213,7 @@ Resources:
 
   UpdateDdbWithS3LocationLambdaExecutionRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -221,6 +246,7 @@ Resources:
   #### S3 Lambda Trigger ####
   ExistingBucketConfiguration:
     Type: Custom::LoadLambda
+    Condition: IsAllowedRegion
     DependsOn:
       - BucketPermission
     Properties:
@@ -232,6 +258,7 @@ Resources:
 
   S3BucketConfigurationLambda:
     Type: AWS::Lambda::Function
+    Condition: IsAllowedRegion
     Properties:
       Description: S3 Object Custom Resource
       Handler: S3NotificationConfiguration.handler
@@ -254,6 +281,7 @@ Resources:
 
   S3BucketConfigurationLambdaExecutionRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -289,6 +317,7 @@ Resources:
 
   BucketPermission:
     Type: AWS::Lambda::Permission
+    Condition: IsAllowedRegion
     Properties:
       Action: "lambda:InvokeFunction"
       FunctionName: !Ref UpdateDdbWithS3LocationLambda
@@ -299,6 +328,7 @@ Resources:
   #### DynamoDb ####
   chatContactDataTable:
     Type: AWS::DynamoDB::Table
+    Condition: IsAllowedRegion
     Properties:
       AttributeDefinitions:
         - AttributeName: "contactId"
@@ -332,6 +362,7 @@ Resources:
   #### Website #####
   CreateWebsiteS3Bucket:
     Type: "AWS::S3::Bucket"
+    Condition: IsAllowedRegion
     Properties:
       BucketName: !Ref WebsiteS3BucketName
       AccessControl: LogDeliveryWrite
@@ -360,6 +391,7 @@ Resources:
 
   s3BucketPolicy:
     Type: AWS::S3::BucketPolicy
+    Condition: IsAllowedRegion
     Properties:
       Bucket: !Ref CreateWebsiteS3Bucket
       PolicyDocument:
@@ -375,6 +407,7 @@ Resources:
 
   CustomResourceHelper:
     Type: AWS::Lambda::Function
+    Condition: IsAllowedRegion
     Properties:
       Code:
         S3Bucket: !Join
@@ -398,6 +431,7 @@ Resources:
 
   CustomResourceHelperIamRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -444,6 +478,7 @@ Resources:
 
   ConfigureWebsite:
     Type: Custom::LoadLambda
+    Condition: IsAllowedRegion
     DependsOn:
       - CreateWebsiteS3Bucket
     Properties:
@@ -475,6 +510,7 @@ Resources:
 
   SolutionUuid:
     Type: "Custom::LoadLambda"
+    Condition: IsAllowedRegion
     Properties:
       ServiceToken: !GetAtt CustomResourceHelper.Arn
       Region: !Ref AWS::Region
@@ -482,12 +518,14 @@ Resources:
 
   CloudFrontDistributionAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Condition: IsAllowedRegion
     Properties:
       CloudFrontOriginAccessIdentityConfig:
         Comment: "CloudFront OAI for Amazon Connect Chat"
 
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
+    Condition: IsAllowedRegion
     DependsOn:
       - CustomResourceHelper
     Properties:
@@ -533,12 +571,14 @@ Resources:
 
   ApiGatewayRestAPI: #DONE
     Type: AWS::ApiGateway::RestApi
+    Condition: IsAllowedRegion
     Properties:
       Name: "initiateChatConnection"
       Description: "API to initiate chat with Amazon Connect"
 
   LambdaApiGatewayInvokePermission: #DONE
     Type: AWS::Lambda::Permission
+    Condition: IsAllowedRegion
     Properties:
       Action: "lambda:InvokeFunction"
       FunctionName: !GetAtt InitiateChatLambda.Arn
@@ -547,6 +587,7 @@ Resources:
 
   ApiGatewayDeployment:
     Type: AWS::ApiGateway::Deployment
+    Condition: IsAllowedRegion
     DependsOn:
       - ApiGatewayRootMethod
     Properties:
@@ -555,6 +596,7 @@ Resources:
 
   ApiGatewayRootMethod: #DONE
     Type: AWS::ApiGateway::Method
+    Condition: IsAllowedRegion
     DependsOn: LambdaApiGatewayInvokePermission
     Properties:
       AuthorizationType: "NONE"
@@ -580,6 +622,7 @@ Resources:
 
   ApiGatewayOptionsMethod: #DONE
     Type: AWS::ApiGateway::Method
+    Condition: IsAllowedRegion
     Properties:
       ResourceId: !GetAtt ApiGatewayRestAPI.RootResourceId
       RestApiId: !Ref ApiGatewayRestAPI
@@ -612,6 +655,7 @@ Resources:
 
   ChatUXCreator:
     Type: "AWS::Lambda::Function"
+    Condition: IsAllowedRegion
     Properties:
       Description: >
         AWS Lambda Function that will create the chat UX and upload it to the S3 bucket
@@ -636,6 +680,7 @@ Resources:
 
   InvokeChatUXCreator:
     Type: Custom::CreateChatUX
+    Condition: IsAllowedRegion
     DependsOn:
       - CreateWebsiteS3Bucket
     Properties:
@@ -649,6 +694,7 @@ Resources:
 
   ChatUXCreatorRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -680,20 +726,26 @@ Resources:
 
 Outputs:
   cloudFrontDistribution:
+    Condition: IsAllowedRegion
     Description: The domain name of the CloudFront Distribution to host the chat website
     Value: !GetAtt CloudFrontDistribution.DomainName
   initiateChatLambda:
+    Condition: IsAllowedRegion
     Description: The ARN of the Lambda function created to initiate chat
     Value: !GetAtt InitiateChatLambda.Arn
   apiGatewayEndpoint:
+    Condition: IsAllowedRegion
     Description: The ARN of the API Gateway endpoint that triggers the Lambda function to initiate the chat
     Value: !Ref ApiGatewayRestAPI
   InitiateChatLambdaExecutionRole:
+    Condition: IsAllowedRegion
     Description: The ARN of the IAM role used by the Lambda function to initiate the chat
     Value: !GetAtt InitiateChatLambdaExecutionRole.Arn
   websiteS3Bucket:
+    Condition: IsAllowedRegion
     Description: The ARN of the S3 Bucket used to host the website
     Value: !GetAtt CreateWebsiteS3Bucket.Arn
   chatContactDataTable:
+    Condition: IsAllowedRegion
     Description: Name of the new table to store the contact data related to chats.
     Value: !Ref chatContactDataTable

--- a/cloudformationTemplates/startChatContactAPI/cloudformation.yaml
+++ b/cloudformationTemplates/startChatContactAPI/cloudformation.yaml
@@ -10,6 +10,25 @@ Mappings:
       S3Bucket: "start-chat-contact-proxy-cfn"
       S3Key: "deployment/"
       SolutionID: "AC0002"
+  AllowedRegions:
+    us-east-1:
+      Allowed: "true"
+    us-west-2:
+      Allowed: "true"
+    ap-southeast-2:
+      Allowed: "true"
+    ap-northeast-1:
+      Allowed: "true"
+    eu-central-1:
+      Allowed: "true"
+    eu-west-2:
+      Allowed: "true"
+    ap-southeast-1:
+      Allowed: "true"
+    ca-central-1:
+      Allowed: "true"
+    ap-northeast-2:
+      Allowed: "true"
 
 Parameters:
   contactFlowId:
@@ -32,15 +51,19 @@ Parameters:
 
 Conditions:
   AnonymousUsageMetrics: !Equals [!Ref allowAnonymousUsageMetrics, "Yes"]
+  IsAllowedRegion: !Equals [!FindInMap [AllowedRegions, !Ref "AWS::Region", Allowed], "true"]
 
 Outputs:
   StartChatLambda:
+    Condition: IsAllowedRegion
     Description: The ARN of the Lambda function created to initiate chat
     Value: !GetAtt StartChatLambda.Arn
   ApiGatewayEndoint:
+    Condition: IsAllowedRegion
     Description: The ARN of the API Gateway endpoint that triggers the Lambda function to initiate the chat
     Value: !Ref ApiGatewayRestAPI
   StartChatLambdaExecutionRole:
+    Condition: IsAllowedRegion
     Description: The ARN of the IAM role used by the Lambda function to initiate the chat
     Value: !GetAtt StartChatLambdaExecutionRole.Arn
 
@@ -48,6 +71,7 @@ Resources:
   #### Lambda #####
   ChatSDKLayer:
     Type: AWS::Lambda::LayerVersion
+    Condition: IsAllowedRegion
     Properties:
       CompatibleRuntimes:
         - "nodejs18.x"
@@ -66,6 +90,7 @@ Resources:
 
   StartChatLambda:
     Type: "AWS::Lambda::Function"
+    Condition: IsAllowedRegion
     Properties:
       Description: AWS Lambda Function to initiate the chat with the end user
       Handler: "startChatContact.handler"
@@ -96,6 +121,7 @@ Resources:
 
   StartChatLambdaExecutionRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -131,12 +157,14 @@ Resources:
 
   ApiGatewayRestAPI:
     Type: AWS::ApiGateway::RestApi
+    Condition: IsAllowedRegion
     Properties:
       Name: "StartChatContact"
       Description: "API to initiate chat with Amazon Connect"
 
   LambdaApiGatewayInvokePermission:
     Type: AWS::Lambda::Permission
+    Condition: IsAllowedRegion
     Properties:
       Action: "lambda:InvokeFunction"
       FunctionName: !GetAtt StartChatLambda.Arn
@@ -145,6 +173,7 @@ Resources:
 
   ApiGatewayDeployment:
     Type: AWS::ApiGateway::Deployment
+    Condition: IsAllowedRegion
     DependsOn:
       - ApiGatewayRootMethod
     Properties:
@@ -153,6 +182,7 @@ Resources:
 
   ApiGatewayRootMethod:
     Type: AWS::ApiGateway::Method
+    Condition: IsAllowedRegion
     DependsOn: LambdaApiGatewayInvokePermission
     Properties:
       AuthorizationType: "NONE"
@@ -180,6 +210,7 @@ Resources:
 
   ApiGatewayOptionsMethod:
     Type: AWS::ApiGateway::Method
+    Condition: IsAllowedRegion
     Properties:
       ResourceId: !GetAtt ApiGatewayRestAPI.RootResourceId
       RestApiId: !Ref ApiGatewayRestAPI
@@ -211,6 +242,7 @@ Resources:
   #### Metrics ####
   CustomResourceHelper:
     Type: AWS::Lambda::Function
+    Condition: IsAllowedRegion
     Properties:
       Code:
         S3Bucket: !Join
@@ -234,6 +266,7 @@ Resources:
 
   CustomResourceHelperIamRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -289,6 +322,7 @@ Resources:
 
   SolutionUuid:
     Type: "Custom::LoadLambda"
+    Condition: IsAllowedRegion
     Properties:
       ServiceToken:
         Fn::GetAtt:

--- a/cloudformationTemplates/urlPreviewForAsyncChat/cloudformation.yaml
+++ b/cloudformationTemplates/urlPreviewForAsyncChat/cloudformation.yaml
@@ -9,6 +9,25 @@ Mappings:
       S3Bucket: "amazon-connect-url-preview-cfn"
       S3Key: "deployment/"
       SolutionID: "AC0003"
+  AllowedRegions:
+    us-east-1:
+      Allowed: "true"
+    us-west-2:
+      Allowed: "true"
+    ap-southeast-2:
+      Allowed: "true"
+    ap-northeast-1:
+      Allowed: "true"
+    eu-central-1:
+      Allowed: "true"
+    eu-west-2:
+      Allowed: "true"
+    ap-southeast-1:
+      Allowed: "true"
+    ca-central-1:
+      Allowed: "true"
+    ap-northeast-2:
+      Allowed: "true"
 
 Parameters:
   WebsiteS3BucketName:
@@ -66,11 +85,13 @@ Parameters:
 
 Conditions:
   AnonymousUsageMetrics: !Equals [!Ref allowAnonymousUsageMetrics, "Yes"]
+  IsAllowedRegion: !Equals [!FindInMap [AllowedRegions, !Ref "AWS::Region", Allowed], "true"]
 
 Resources:
   #### DynamoDb for user state####
   chatContactDataTable:
     Type: AWS::DynamoDB::Table
+    Condition: IsAllowedRegion
     Properties:
       AttributeDefinitions:
         - AttributeName: "contactId"
@@ -104,6 +125,7 @@ Resources:
   ### DDB for url preview cache ###
   UrlPreviewCacheTable:
     Type: AWS::DynamoDB::Table
+    Condition: IsAllowedRegion
     Properties:
       AttributeDefinitions:
         - AttributeName: "normalized_url"
@@ -121,6 +143,7 @@ Resources:
   #### Lambda #####
   UrlPreviewLayer:
     Type: AWS::Lambda::LayerVersion
+    Condition: IsAllowedRegion
     Properties:
       CompatibleRuntimes:
         - "nodejs14.x"
@@ -142,6 +165,7 @@ Resources:
 
   UrlPreviewLambda:
     Type: "AWS::Lambda::Function"
+    Condition: IsAllowedRegion
     Properties:
       Description: AWS Lambda Function to generate URL preview
       Handler: "AmazonConnectChatLinkPreviewLambdaEntryPoint.handler"
@@ -172,6 +196,7 @@ Resources:
 
   ChatSDKLayer:
     Type: AWS::Lambda::LayerVersion
+    Condition: IsAllowedRegion
     Properties:
       CompatibleRuntimes:
         - "nodejs14.x"
@@ -190,6 +215,7 @@ Resources:
 
   UrlPreviewLambdaExecutionRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -224,6 +250,7 @@ Resources:
 
   InitiateChatLambda:
     Type: "AWS::Lambda::Function"
+    Condition: IsAllowedRegion
     Properties:
       Description: AWS Lambda Function to initiate the chat with the end user
       Handler: "startChatContact.handler"
@@ -256,6 +283,7 @@ Resources:
 
   InitiateChatLambdaExecutionRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -296,6 +324,7 @@ Resources:
 
   UpdateDdbWithS3LocationLambda:
     Type: "AWS::Lambda::Function"
+    Condition: IsAllowedRegion
     Properties:
       Description: AWS Lambda Function to update the DDB with the S3 location of the chat transcript
       Handler: "updateChatDdbWithS3Key.handler"
@@ -323,6 +352,7 @@ Resources:
 
   UpdateDdbWithS3LocationLambdaExecutionRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -355,6 +385,7 @@ Resources:
   #### S3 Lambda Trigger ####
   ExistingBucketConfiguration:
     Type: Custom::LoadLambda
+    Condition: IsAllowedRegion
     DependsOn:
       - BucketPermission
     Properties:
@@ -366,6 +397,7 @@ Resources:
 
   S3BucketConfigurationLambda:
     Type: AWS::Lambda::Function
+    Condition: IsAllowedRegion
     Properties:
       Description: S3 Object Custom Resource
       Handler: S3NotificationConfiguration.handler
@@ -388,6 +420,7 @@ Resources:
 
   S3BucketConfigurationLambdaExecutionRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -412,6 +445,7 @@ Resources:
 
   BucketPermission:
     Type: AWS::Lambda::Permission
+    Condition: IsAllowedRegion
     Properties:
       Action: "lambda:InvokeFunction"
       FunctionName: !Ref UpdateDdbWithS3LocationLambda
@@ -422,6 +456,7 @@ Resources:
   #### Website #####
   CreateWebsiteS3Bucket:
     Type: "AWS::S3::Bucket"
+    Condition: IsAllowedRegion
     Properties:
       BucketName: !Ref WebsiteS3BucketName
       AccessControl: LogDeliveryWrite
@@ -453,6 +488,7 @@ Resources:
 
   s3BucketPolicy:
     Type: AWS::S3::BucketPolicy
+    Condition: IsAllowedRegion
     Properties:
       Bucket: !Ref CreateWebsiteS3Bucket
       PolicyDocument:
@@ -468,6 +504,7 @@ Resources:
 
   CustomResourceHelper:
     Type: AWS::Lambda::Function
+    Condition: IsAllowedRegion
     Properties:
       Code:
         S3Bucket: !Join
@@ -491,6 +528,7 @@ Resources:
 
   CustomResourceHelperIamRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -537,6 +575,7 @@ Resources:
 
   ConfigureWebsite:
     Type: Custom::LoadLambda
+    Condition: IsAllowedRegion
     DependsOn:
       - CreateWebsiteS3Bucket
     Properties:
@@ -568,6 +607,7 @@ Resources:
 
   SolutionUuid:
     Type: "Custom::LoadLambda"
+    Condition: IsAllowedRegion
     Properties:
       ServiceToken: !GetAtt CustomResourceHelper.Arn
       Region: !Ref AWS::Region
@@ -575,12 +615,14 @@ Resources:
 
   CloudFrontDistributionAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Condition: IsAllowedRegion
     Properties:
       CloudFrontOriginAccessIdentityConfig:
         Comment: "CloudFront OAI for Amazon Connect Chat"
 
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
+    Condition: IsAllowedRegion
     DependsOn:
       - CustomResourceHelper
     Properties:
@@ -625,12 +667,14 @@ Resources:
 
   ApiGatewayRestAPI:
     Type: AWS::ApiGateway::RestApi
+    Condition: IsAllowedRegion
     Properties:
       Name: "initiateChatConnection"
       Description: "API to initiate chat with Amazon Connect"
 
   LambdaApiGatewayInvokePermission:
     Type: AWS::Lambda::Permission
+    Condition: IsAllowedRegion
     Properties:
       Action: "lambda:InvokeFunction"
       FunctionName: !GetAtt InitiateChatLambda.Arn
@@ -639,6 +683,7 @@ Resources:
 
   ApiGatewayDeployment:
     Type: AWS::ApiGateway::Deployment
+    Condition: IsAllowedRegion
     DependsOn:
       - ApiGatewayRootMethod
     Properties:
@@ -647,6 +692,7 @@ Resources:
 
   ApiGatewayRootMethod:
     Type: AWS::ApiGateway::Method
+    Condition: IsAllowedRegion
     DependsOn: LambdaApiGatewayInvokePermission
     Properties:
       AuthorizationType: "NONE"
@@ -672,6 +718,7 @@ Resources:
 
   ApiGatewayOptionsMethod:
     Type: AWS::ApiGateway::Method
+    Condition: IsAllowedRegion
     Properties:
       ResourceId: !GetAtt ApiGatewayRestAPI.RootResourceId
       RestApiId: !Ref ApiGatewayRestAPI
@@ -703,6 +750,7 @@ Resources:
   ### URL PREVIEW API GW resource
   UrlPreviewResource:
     Type: "AWS::ApiGateway::Resource"
+    Condition: IsAllowedRegion
     Properties:
       RestApiId: !Ref ApiGatewayRestAPI
       ParentId: !GetAtt ApiGatewayRestAPI.RootResourceId
@@ -710,6 +758,7 @@ Resources:
 
   UrlPreviewInvokePermission:
     Type: AWS::Lambda::Permission
+    Condition: IsAllowedRegion
     Properties:
       Action: "lambda:InvokeFunction"
       FunctionName: !GetAtt UrlPreviewLambda.Arn
@@ -718,6 +767,7 @@ Resources:
 
   UrlPreviewMethod:
     Type: AWS::ApiGateway::Method
+    Condition: IsAllowedRegion
     DependsOn: UrlPreviewLambda
     Properties:
       AuthorizationType: "NONE"
@@ -743,6 +793,7 @@ Resources:
 
   UrlPreviewOptionsMethod:
     Type: AWS::ApiGateway::Method
+    Condition: IsAllowedRegion
     Properties:
       ResourceId: !Ref UrlPreviewResource
       RestApiId: !Ref ApiGatewayRestAPI
@@ -775,6 +826,7 @@ Resources:
 
   ChatUXCreator:
     Type: "AWS::Lambda::Function"
+    Condition: IsAllowedRegion
     Properties:
       Description: >
         AWS Lambda Function that will create the chat UX and upload it to the S3 bucket
@@ -799,6 +851,7 @@ Resources:
 
   InvokeChatUXCreator:
     Type: Custom::CreateChatUX
+    Condition: IsAllowedRegion
     DependsOn:
       - CreateWebsiteS3Bucket
     Properties:
@@ -812,6 +865,7 @@ Resources:
 
   ChatUXCreatorRole:
     Type: "AWS::IAM::Role"
+    Condition: IsAllowedRegion
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -843,20 +897,26 @@ Resources:
 
 Outputs:
   cloudFrontDistribution:
+    Condition: IsAllowedRegion
     Description: The domain name of the CloudFront Distribution to host the chat website
     Value: !GetAtt CloudFrontDistribution.DomainName
   initiateChatLambda:
+    Condition: IsAllowedRegion
     Description: The ARN of the Lambda function created to initiate chat
     Value: !GetAtt InitiateChatLambda.Arn
   apiGatewayEndpoint:
+    Condition: IsAllowedRegion
     Description: The ARN of the API Gateway endpoint that triggers the Lambda function to initiate the chat
     Value: !Ref ApiGatewayRestAPI
   InitiateChatLambdaExecutionRole:
+    Condition: IsAllowedRegion
     Description: The ARN of the IAM role used by the Lambda function to initiate the chat
     Value: !GetAtt InitiateChatLambdaExecutionRole.Arn
   websiteS3Bucket:
+    Condition: IsAllowedRegion
     Description: The ARN of the S3 Bucket used to host the website
     Value: !GetAtt CreateWebsiteS3Bucket.Arn
   chatContactDataTable:
+    Condition: IsAllowedRegion
     Description: Name of the new table to store the contact data related to chats.
     Value: !Ref chatContactDataTable


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Creating `AllowedRegions` condition on all `cloudformation.yaml` resources to ensure that the cloudformation templates are only run on Amazon Connect enabled regions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
